### PR TITLE
Reduce duplicate PR builds

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -77,12 +77,12 @@ jobs:
       uses: actions/upload-artifact@v3
       if: matrix.os != 'windows-latest'
       with:
-          name: bmai-${{runner.os}}
+          name: bmai-${{ runner.os }}-${{ env.BUILD_TYPE }}
           path: ./build/bmai
 
     - name: Upload WINDOWS Binary
       uses: actions/upload-artifact@v3
       if: matrix.os == 'windows-latest'
       with:
-          name: bmai-${{runner.os}}
-          path: ${{github.workspace}}\build\${{ env.BUILD_TYPE }}\bmai.exe
+          name: bmai-${{ runner.os }}-${{ env.BUILD_TYPE }}
+          path: ${{ github.workspace }}\build\${{ env.BUILD_TYPE }}\bmai.exe

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -1,8 +1,14 @@
 name: CMake
 
-on: 
+# if you are doing development on another branch and want GHActions to auto build the branch
+# then add the branch name to the `push` section below
+# you only need to make that change ON THE BRANCH to be built
+# I like to remove it when merging into `main`
+on:
   push:
+    branches: [ main ]
   pull_request:
+    branches: [ main ]
 
   # this allows us to manually dispatch the build from GH Actions UI
   workflow_dispatch:

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -30,7 +30,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: lukka/get-cmake@latest
 
     - name: CMake Configure

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -35,7 +35,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL


### PR DESCRIPTION
I noticed with the last PR each set of builds happened twice. I think 1 build was for the PR and 1 build was for the fact that code was pushed to a branch. thats a lot of builds. 

- this PR pairs the number of builds back a little bit

- this also incorporates the dependabots suggested changes from #26 to increase some version numbers. ill go close that PR

- this also adds 'Release' or 'Debug' to the name of the build artifact download